### PR TITLE
Fixed Missing required attribute `homepage`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "homepage": "https://adtrace.io",
   "author": "AdTrace",
   "license": "ISC"
 }


### PR DESCRIPTION
@arefhosseini When I run `pod install` I have the following error

```
[!] The `react-native-adtrace` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | github_sources: Github repositories should end in `.git`.
    - WARN  | description: The description is equal to the summary.
```

I fixed it ,missing https://github.com/adtrace/adtrace_sdk_react_native/blob/master/react-native-adtrace.podspec#L12
